### PR TITLE
Fixed up handling of project.properties file

### DIFF
--- a/project/Vagrantfile
+++ b/project/Vagrantfile
@@ -14,7 +14,7 @@ def load_properties(properties_filename, prefix = "")
         if (line[0] != ?#) && (line[0] != ?=) && (line[0] != "")
           i = line.index('=')
           if i
-            key = prefix + line[0..i - 1].strip
+            key = prefix + line[0..i - 1].strip.upcase
             value = line[i + 1..-1].strip
             properties[key] = value
           end

--- a/project/project.properties
+++ b/project/project.properties
@@ -1,2 +1,2 @@
-ml-version=8
-nr-hosts=3
+ml_version=8
+nr_hosts=3


### PR DESCRIPTION
The code in Vagrant file exepects keys in project.properties file to be uppercase.  The supplied example has them in lowercase.  So the Vagrant always uses default values not the ones from the file.    Also the example project.properties file uses dashes instead of underscores.

This commit fixes both issues,  by relaxing project.properties to be case insensitve and also changing dashes to underscores.