### PR TITLE
Fixed case sensitivy problem with provision script

### DIFF
--- a/opt/vagrant/bootstrap-centos-master.sh
+++ b/opt/vagrant/bootstrap-centos-master.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 echo "running $0 $@"
 sudo /opt/vagrant/restore-yum-cache.sh
-sudo /opt/vagrant/install-ml-centos.sh $2
+sudo /opt/vagrant/install-ml-CentOS.sh $2
 sudo /opt/vagrant/setup-ml-master.sh $1 $2 $3
 sudo /opt/vagrant/install-node.sh
 sudo /opt/vagrant/install-mlcp.sh $2


### PR DESCRIPTION
You capitalized CentOS in your bootstrap script.  This doesn't work on case sensitive scenarios.  Such as when trying to provision into VCenter
