### PR TITLE
#28 Add JDK to CentOS VM

### DIFF
--- a/opt/vagrant/bootstrap-centos-extra.sh
+++ b/opt/vagrant/bootstrap-centos-extra.sh
@@ -4,3 +4,4 @@ sudo /opt/vagrant/restore-yum-cache.sh
 sudo /opt/vagrant/install-ml-centos.sh $2
 sudo /opt/vagrant/setup-ml-extra.sh $@
 sudo /opt/vagrant/backup-yum-cache.sh
+sudo /opt/vagrant/set-env-vars.sh

--- a/opt/vagrant/bootstrap-centos-master.sh
+++ b/opt/vagrant/bootstrap-centos-master.sh
@@ -9,3 +9,4 @@ sudo /opt/vagrant/install-user.sh $4
 sudo /opt/vagrant/setup-git.sh $4
 sudo /opt/vagrant/setup-tomcat.sh
 sudo /opt/vagrant/backup-yum-cache.sh
+sudo /opt/vagrant/set-env-vars.sh

--- a/opt/vagrant/install-mlcp.sh
+++ b/opt/vagrant/install-mlcp.sh
@@ -2,7 +2,7 @@
 echo "running $0 $@"
 
 yum -y install zip unzip
-yum -y install java
+yum -y install java-1.7.0-openjdk-devel
 
 if [ "$1" -eq "8" ]; then
     echo "Installing MLCP 1.3-1..."

--- a/opt/vagrant/set-env-vars.sh
+++ b/opt/vagrant/set-env-vars.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+echo "running $0 $@"
+
+# Vagrant Environment Variables
+echo "Setting environment variables..."
+echo "export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.75.x86_64"  >> /home/vagrant/.bashrc


### PR DESCRIPTION
Update install-mlcp.sh to install the JDK rather than the JRE.  Add JAVA_HOME to
the vagrant user’s environment.