### PR TITLE
Add network proxy configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ You first need to download and install prerequisites and mlvagrant itself:
 - Download and install [Vagrant](https://www.vagrantup.com/downloads.html)
 - Install the [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager) plugin:
   - `vagrant plugin install vagrant-hostmanager`
+- If a proxy is required to access the external network, install the [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf) plugin:
+  - `vagrant plugin install vagrant-proxyconf`
 - Create /space/software (**For Windows**: `c:\space\software`):
   - `sudo mkdir -p /space/software`
 - Make sure Vagrant has write access to that folder:
@@ -136,6 +138,14 @@ Note: enabling this makes your VMs accessible from outside, beware of security l
 
 ### priv_net_ip
 Assign dedicated private IP to master node - slaves get same ip + i
+
+### net_proxy
+URL for a network proxy for FTP, HTTP, and HTTPS requests
+
+Use of this setting requires installation of the `vagrant-proxyconf` plugin
+
+### no_proxy
+Hostnames or IP addresses that do not require use of the network proxy
 
 ### shared_folder_host/shared_folder_guest
 Mount an extra folder from host on vm - project dir is automatically shared as /vagrant

--- a/project/Vagrantfile
+++ b/project/Vagrantfile
@@ -90,6 +90,10 @@ end
 @net_proxy = ENV["MLV_NET_PROXY"] || @properties["NET_PROXY"] || ""
 @no_proxy = ENV["MLV_NO_PROXY"] || @properties["NO_PROXY"] || "localhost,127.0.0.1"
 
+unless @net_proxy.empty? or Vagrant.has_plugin?("vagrant-proxyconf")
+  abort 'To use net_proxy setting, run "vagrant plugin install vagrant-proxyconf" first.'
+end
+
 @vm_name = get_vm_name("{i}")
 
 puts "Loading project #{@project_name}.." unless @command == "global-status"
@@ -136,11 +140,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     mastername = get_vm_name(1)
 
-    hostnames = (1..@nr_hosts).map{|i| get_vm_name(i)}.join(",")
-    config.proxy.ftp = @net_proxy
-    config.proxy.http = @net_proxy
-    config.proxy.https = @net_proxy
-    config.proxy.no_proxy = "#{@no_proxy},#{hostnames}"
+    unless @net_proxy.empty?
+      hostnames = (1..@nr_hosts).map{|i| get_vm_name(i)}.join(",")
+      config.proxy.ftp = @net_proxy
+      config.proxy.http = @net_proxy
+      config.proxy.https = @net_proxy
+      config.proxy.no_proxy = "#{@no_proxy},#{hostnames}"
+    end
 
     config.hostmanager.enabled = false
     config.hostmanager.manage_host = true

--- a/project/Vagrantfile
+++ b/project/Vagrantfile
@@ -87,6 +87,8 @@ end
 @priv_net_ip = ENV["MLV_PRIV_NET_IP"] || @properties["PRIV_NET_IP"] || ""
 @shared_folder_host = ENV["MLV_SHARED_FOLDER_HOST"] || @properties["SHARED_FOLDER_HOST"] || ""
 @shared_folder_guest = ENV["MLV_SHARED_FOLDER_GUEST"] || @properties["SHARED_FOLDER_GUEST"] || ""
+@net_proxy = ENV["MLV_NET_PROXY"] || @properties["NET_PROXY"] || ""
+@no_proxy = ENV["MLV_NO_PROXY"] || @properties["NO_PROXY"] || "localhost,127.0.0.1"
 
 @vm_name = get_vm_name("{i}")
 
@@ -133,6 +135,12 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     mastername = get_vm_name(1)
+
+    hostnames = (1..@nr_hosts).map{|i| get_vm_name(i)}.join(",")
+    config.proxy.ftp = @net_proxy
+    config.proxy.http = @net_proxy
+    config.proxy.https = @net_proxy
+    config.proxy.no_proxy = "#{@no_proxy},#{hostnames}"
 
     config.hostmanager.enabled = false
     config.hostmanager.manage_host = true

--- a/project/project.properties
+++ b/project/project.properties
@@ -59,6 +59,16 @@ master_cpus=2
 #priv_net_ip=
 
 ##
+# Network proxy - requires vagrant-proxyconf plugin
+#
+#net_proxy=http://proxy:8080/
+
+##
+# Hosts that do not require network proxy
+#
+#no_proxy=localhost,127.0.0.1
+
+##
 # Mount an extra folder from host on vm - project dir is automatically shared as /vagrant
 #
 #shared_folder_host=


### PR DESCRIPTION
Allow configuration of a network proxy for external calls to network.  Adds the ML cluster hostnames to `no_proxy` to ensure connections work between VirtualBox nodes.

Fixes #82 