### PR TITLE
Git should ignore software .vagrant directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 test*
 update*
+software
+project/.vagrant


### PR DESCRIPTION
It's mildly annoying when these folders show up in git as modified