### PR TITLE
Prevent clockskew

### DIFF
--- a/project/Vagrantfile
+++ b/project/Vagrantfile
@@ -281,6 +281,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
         vb.customize ["modifyvm", :id, "--cableconnected2", "on"]
         #vb.gui = true # for debugging
+        #reset vm clock if vm time varies from host by more than a second to prevent clockskew
+        vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
     end
 
     config.vm.define mastername do |master|


### PR DESCRIPTION
Reset the clock if time varies from host by more than 1 second to prevent clockskew.

More info on clock sync options for virtualbox can be found [here!](https://www.virtualbox.org/manual/ch09.html#changetimesync)